### PR TITLE
Tag cloud

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -60,6 +60,8 @@ Setting name              what it does ?
 `STATIC_THEME_PATHS`      Static theme paths you want to copy. Default values
                           is `static`, but if your theme have others static paths,
                           you can put them here.
+`TAG_CLOUD_STEPS`         Count of different font sizes in the tag cloud.
+`TAG_CLOUD_MAX_ITEMS`     Maximum tags count in the cloud.
 `THEME`                   theme to use to product the output. can be the
                           complete static path to a theme folder, or chosen
                           between the list of default themes (see below)

--- a/pelican/settings.py
+++ b/pelican/settings.py
@@ -22,6 +22,8 @@ _DEFAULT_CONFIG = {'PATH': None,
                    'CLEAN_URLS': False, # use /blah/ instead /blah.html in urls
                    'RELATIVE_URLS': True,
                    'DEFAULT_LANG': 'en',
+                   'TAG_CLOUD_STEPS': 4,
+                   'TAG_CLOUD_MAX_ITEMS': 100,
                   }
 
 def read_settings(filename):


### PR DESCRIPTION
I added a tag cloud calculation into the ArticleGenerator. Cloud saved as `tag_cloud` context variable. Here is [example](https://github.com/svetlyak40wt/dev.svetlyak/blob/master/theme/templates/index.html) how to render it in the template. And this is the [resulting](http://dev.svetlyak.ru/) page.
